### PR TITLE
create sandbox for `pytest` "on-the-fly", rather than hardcoding

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -149,8 +149,6 @@ jobs:
         # use the find-links feature to look in the directory and pick the correct wheel
         # works also on Windows
         pip install --find-links=dist scribl
-        # FIXME: manually create the sandbox, otherwise they fail
-        mkdir tests/test_sandbox
         pytest -v tests
     # skip uploading separate files for each CI run (need just one wheel/dist done in 'dist' job, below)
     #- name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -245,13 +245,14 @@ in the main documentation.
    pip install .[test]
    ```
 
-3. create the testing sandbox:
+3. run `pytest`
 
-   ``` shell
-   mkdir tests/test_sandbox
-   ```
-
-4. run `pytest`
+   Note that the output sandbox test files are created in the system
+   temporary directory, e.g. on Linux
+   [`pytest` creates a directory structure](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-default-base-temporary-directory)
+   `/tmp/pytest-of-USER/pytest-NUM/scribl_sandboxNUM` where `USER` is
+   the current user and `NUM` is incremented on each run. Only the
+   last three directories are retained.
 
 ## Contributing to `scribl`
 


### PR DESCRIPTION
uses `pytest`'s `tmpdir_factory` for sandbox.  this avoids having to manually create a `test_sandbox` directory (#15)

@benlansdell: can you pull this branch and see if this PR works for you?