### PR TITLE
Fix `pip install` during `pytest`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -145,10 +145,11 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      shell: bash
       run: |
         # use the find-links feature to look in the directory and pick the correct wheel
         # works also on Windows
-        pip install dist/scribl*.whl
+        pip install dist/scribl*.wh
         pytest -v tests
     # skip uploading separate files for each CI run (need just one wheel/dist done in 'dist' job, below)
     #- name: Upload artifact

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -149,7 +149,7 @@ jobs:
       run: |
         # use the find-links feature to look in the directory and pick the correct wheel
         # works also on Windows
-        pip install dist/scribl*.wh
+        pip install dist/scribl*.whl
         pytest -v tests
     # skip uploading separate files for each CI run (need just one wheel/dist done in 'dist' job, below)
     #- name: Upload artifact

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -145,10 +145,10 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      # force use of bash on all platforms, so wildcard expansion works on Windows
+      # (otherwise would use powershell on Windows, which fails)
       shell: bash
       run: |
-        # use the find-links feature to look in the directory and pick the correct wheel
-        # works also on Windows
         pip install dist/scribl*.whl
         pytest -v tests
     # skip uploading separate files for each CI run (need just one wheel/dist done in 'dist' job, below)


### PR DESCRIPTION
force use of `bash` on all platforms, when running `pytest`, so wildcard expansion works on Windows (the default powershell on Windows, fails)
     
