### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -135,7 +135,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: false
+        allow-prereleases: true
     - name: Build wheel and sdist
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -125,9 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # FIXME: disable 3.13 unti pandas available
-        # https://github.com/pandas-dev/pandas/issues/58734
-        python-version: ["3.12", "3.11", "3.10", "3.9"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`pandas` 2.2.3 has Python 3.13 support, so we can now add this to continuous integration builds